### PR TITLE
Removed Skytest

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,7 +1,6 @@
 default
 farming
 moreores?
-skytest?
 technic?
 bonemeal?
 dye?

--- a/optional_depends/skytest.lua
+++ b/optional_depends/skytest.lua
@@ -1,4 +1,4 @@
---[
+--[[
 minetest.register_craft({
         output = "mystical_agriculture:bone_seed",
         recipe = {
@@ -23,4 +23,4 @@ minetest.register_craft({
             {"mystical_agriculture:blank_seed","skytest:bonemeal","mystical_agriculture:blank_seed"},
         }
     })
-]--
+]]

--- a/optional_depends/skytest.lua
+++ b/optional_depends/skytest.lua
@@ -1,3 +1,4 @@
+--[
 minetest.register_craft({
         output = "mystical_agriculture:bone_seed",
         recipe = {
@@ -22,3 +23,4 @@ minetest.register_craft({
             {"mystical_agriculture:blank_seed","skytest:bonemeal","mystical_agriculture:blank_seed"},
         }
     })
+]--


### PR DESCRIPTION
So I have found out skytest is an unreasonable mod, which gives errors with the new versions, has weird optional dependencies, hard-to-find dependency mods, and most of all latest version links are broken. So I have just kept it as a comments file in the folder and removed its name from the dependencies list. If a player wants, he can put it as an optional depends and make the code executable. 
So here is a change I propose.
I hope it gets accepted, but if you don't, don't merge it.